### PR TITLE
feat/register - user register

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import dotenv from 'dotenv';
 import connectDB from './config/db';
 import userRoutes from './routes/userRoutes';
+
 dotenv.config();
 
 const app = express();

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+import { registerUser } from '../services/userService';
+
+export const register = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { username, email, password } = req.body;
+    await registerUser(username, email, password);
+    res.status(201).json({ message: '회원가입이 완료되었습니다.' });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,25 +1,18 @@
 import mongoose, { Schema, Document } from 'mongoose';
 
 export interface IUser extends Document {
+  username: string;
   email: string;
   password: string;
 }
 
-const userSchema = new Schema<IUser>(
+const UserSchema: Schema = new Schema<IUser>(
   {
-    email: {
-      type: String,
-      required: true,
-      unique: true,
-    },
-    password: {
-      type: String,
-      required: true,
-    },
+    username: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
   },
-  {
-    timestamps: true,
-  }
+  { timestamps: true }
 );
 
-export const User = mongoose.model<IUser>('User', userSchema);
+export const User = mongoose.model<IUser>('User', UserSchema);

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -1,0 +1,10 @@
+import { User, IUser } from '../models/user';
+
+export const createUser = async (userData: Partial<IUser>): Promise<IUser> => {
+  const user = new User(userData);
+  return await user.save();
+};
+
+export const findUserByEmail = async (email: string): Promise<IUser | null> => {
+  return await User.findOne({ email });
+};

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { register } from '../controllers/userController';
+import { userValidationRules, validate } from '../validators/userValidator';
+
+const router = express.Router();
+
+router.post('/register', [...userValidationRules, validate], register);
+
+export default router;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,17 @@
+import bcrypt from 'bcrypt';
+import { createUser, findUserByEmail } from '../repositories/userRepository';
+import { BadRequestError } from '../errors/httpError';
+
+export const registerUser = async (
+  username: string,
+  email: string,
+  password: string
+): Promise<void> => {
+  const existingUser = await findUserByEmail(email);
+  if (existingUser) {
+    throw new BadRequestError('이미 사용 중인 이메일입니다.');
+  }
+
+  const hashedPassword = await bcrypt.hash(password, 10);
+  await createUser({ username, email, password: hashedPassword });
+};

--- a/src/validators/userValidator.ts
+++ b/src/validators/userValidator.ts
@@ -1,0 +1,25 @@
+import { body, validationResult } from 'express-validator';
+import { Request, Response, NextFunction } from 'express';
+
+// Validation rules를 정의합니다.
+export const userValidationRules = [
+  body('username').notEmpty().withMessage('사용자 이름은 필수입니다.'),
+  body('email').isEmail().withMessage('유효한 이메일을 입력해주세요.'),
+  body('password')
+    .isLength({ min: 6 })
+    .withMessage('비밀번호는 최소 6자 이상이어야 합니다.'),
+];
+
+// 에러를 처리하는 미들웨어 함수
+export const validate = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ errors: errors.array() });
+  } else {
+    next();
+  }
+};


### PR DESCRIPTION
### PR 종류
- [ ] Bugfix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other

### 핵심 내용
- 회원가입 기능 구현:

  - 사용자 데이터를 MongoDB에 저장할 수 있는 회원가입 API 개발.
  - bcrypt를 이용해 비밀번호를 해싱하여 저장.
  - express-validator를 활용한 입력 값 검증 로직 추가.
  - 유효성 검사를 통과하지 못한 경우, 사용자에게 적절한 에러 메시지를 반환.

- 폴더 구조 및 역할 분리:

  - models: User 스키마 및 모델 정의.
  - repositories: DB와의 직접적인 데이터 처리를 담당하는 레이어 (createUser, findUserByEmail).
  - services: 비즈니스 로직 처리 (회원 중복 검사, 비밀번호 해싱 등).
  - controllers: API 요청 핸들러 (회원가입 로직 실행 및 응답 처리).
  - validators: express-validator를 이용한 입력 값 검증 미들웨어 정의.

### 부가 설명
- devMate 데이터베이스에 users 컬렉션으로 데이터 저장되도록 수정
- Postman을 사용해 POST /api/users/register API를 성공적으로 테스트
- POST /api/users/register: 사용자의 username, email, password를 받아 회원가입 처리