### PR TITLE
feat/login - login process

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -25,5 +25,6 @@ const initializeServer = async () => {
 };
 
 app.use('/boards/:boardId/posts', postRoute);
+app.use('/api/users', userRoutes);
 
 initializeServer();

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,5 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import { registerUser } from '../services/userService';
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  ExtendedJwtPayload,
+} from '../middlewares/authMiddleware';
 
 export const register = async (
   req: Request,
@@ -10,6 +15,43 @@ export const register = async (
     const { username, email, password } = req.body;
     await registerUser(username, email, password);
     res.status(201).json({ message: '회원가입이 완료되었습니다.' });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const login = async (
+  req: Request & { user?: ExtendedJwtPayload },
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const userId = req.user?.userId;
+
+    const accessToken = generateAccessToken(userId as string);
+    const refreshToken = generateRefreshToken(userId as string);
+
+    res.status(200).json({
+      accessToken,
+      refreshToken,
+      message: '로그인 되었습니다.',
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const refreshAccessToken = async (
+  req: Request & { user?: ExtendedJwtPayload },
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const userId = req.user?.userId;
+
+    const newAccessToken = generateAccessToken(userId as string);
+
+    res.status(200).json({ accessToken: newAccessToken });
   } catch (error) {
     next(error);
   }

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,0 +1,56 @@
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { Request as ExpressRequest, Response, NextFunction } from 'express';
+
+interface CustomRequest extends ExpressRequest {
+  user?: string | JwtPayload;
+}
+
+export interface ExtendedJwtPayload extends JwtPayload {
+  userId: string;
+}
+
+export const checkAccessToken = (
+  req: CustomRequest,
+  res: Response,
+  next: NextFunction
+): void => {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+
+  if (!token) {
+    res.status(401).json({ message: '인증 토큰이 없습니다.' });
+    return;
+  }
+
+  jwt.verify(token, process.env.JWT_ACCESS_SECRET!, (err, decoded) => {
+    if (err) {
+      res.status(403).json({ message: '유효하지 않은 토큰입니다.' });
+      return;
+    }
+
+    req.user = decoded as ExtendedJwtPayload;
+    next();
+  });
+};
+
+/**
+ * 액세스 토큰 생성
+ * @param userId 사용자 ID
+ * @returns 액세스 토큰
+ */
+export const generateAccessToken = (userId: string): string => {
+  return jwt.sign({ userId }, process.env.JWT_ACCESS_SECRET!, {
+    expiresIn: process.env.ACCESS_TOKEN_EXPIRY,
+  });
+};
+
+/**
+ * 리프레시 토큰 생성
+ * @param userId 사용자 ID
+ * @returns 리프레시 토큰
+ */
+export const generateRefreshToken = (userId: string): string => {
+  return jwt.sign({ userId }, process.env.JWT_REFRESH_SECRET!, {
+    expiresIn: process.env.REFRESH_TOKEN_EXPIRY,
+  });
+};

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,9 +1,20 @@
 import express from 'express';
-import { register } from '../controllers/userController';
-import { userValidationRules, validate } from '../validators/userValidator';
+import {
+  login,
+  refreshAccessToken,
+  register,
+} from '../controllers/userController';
+import {
+  validateLogin,
+  validate,
+  validateRegister,
+} from '../validators/userValidator';
+import { checkAccessToken } from '../middlewares/authMiddleware';
 
 const router = express.Router();
 
-router.post('/register', [...userValidationRules, validate], register);
+router.post('/register', [...validateRegister, validate], register);
+router.post('/login', [...validateLogin, validate], login);
+router.post('/refresh', checkAccessToken, refreshAccessToken);
 
 export default router;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -15,3 +15,17 @@ export const registerUser = async (
   const hashedPassword = await bcrypt.hash(password, 10);
   await createUser({ username, email, password: hashedPassword });
 };
+
+export const authenticateUser = async (email: string, password: string) => {
+  const user = await findUserByEmail(email);
+  if (!user) {
+    throw new BadRequestError('이메일 또는 비밀번호가 잘못되었습니다.');
+  }
+
+  const isPasswordValid = await bcrypt.compare(password, user.password);
+  if (!isPasswordValid) {
+    throw new BadRequestError('이메일 또는 비밀번호가 잘못되었습니다.');
+  }
+
+  return user;
+};

--- a/src/validators/userValidator.ts
+++ b/src/validators/userValidator.ts
@@ -1,8 +1,7 @@
 import { body, validationResult } from 'express-validator';
 import { Request, Response, NextFunction } from 'express';
 
-// Validation rules를 정의합니다.
-export const userValidationRules = [
+export const validateRegister = [
   body('username').notEmpty().withMessage('사용자 이름은 필수입니다.'),
   body('email').isEmail().withMessage('유효한 이메일을 입력해주세요.'),
   body('password')
@@ -10,7 +9,11 @@ export const userValidationRules = [
     .withMessage('비밀번호는 최소 6자 이상이어야 합니다.'),
 ];
 
-// 에러를 처리하는 미들웨어 함수
+export const validateLogin = [
+  body('email').isEmail().withMessage('유효한 이메일을 입력해주세요.'),
+  body('password').notEmpty().withMessage('비밀번호는 필수 입력 항목입니다.'),
+];
+
 export const validate = (
   req: Request,
   res: Response,


### PR DESCRIPTION
### PR 종류
- [ ] Bugfix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other


### 핵심 내용
- 사용자가 로그인 시, 이메일과 비밀번호를 검증한 뒤, 액세스 토큰과 리프레시 토큰을 발급하여 클라이언트에 반환합니다.
- 액세스 토큰은 사용자 인증에 사용되며, 리프레시 토큰은 액세스 토큰 만료 시 새 토큰 발급에 사용됩니다.



### 부가 설명
- 로그인 흐름

  - 클라이언트가 이메일과 비밀번호로 /login 요청.
  - 서버는 이메일과 비밀번호를 검증 후 액세스 토큰과 리프레시 토큰 생성.
  - 생성된 토큰을 클라이언트에 반환.
- 리프레시 토큰 역할

  - 액세스 토큰 만료 시 /refresh 요청으로 새 액세스 토큰 발급.
- 보안

  - 비밀번호는 bcrypt로 해시 처리.
  - 리프레시 토큰은 서버에서 검증 후 새 토큰 발급.
