### PR TITLE
feat/login - add github login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/bcrypt": "^5.0.2",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/mongoose": "^5.11.97",
+        "axios": "^1.7.9",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -38,6 +39,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
+      },
+      "engines": {
+        "node": "16.x"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1069,6 +1073,21 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1313,6 +1332,17 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1433,6 +1463,14 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -2047,6 +2085,38 @@
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3361,6 +3431,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/bcrypt": "^5.0.2",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/mongoose": "^5.11.97",
+    "axios": "^1.7.9",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import connectDB from './config/db';
+import authRoutes from './routes/authRoutes';
 import postRoute from './routes/postRoute';
 import userRoutes from './routes/userRoutes';
 import commentRoutes from './routes/commentRoutes';
@@ -24,7 +25,7 @@ const initializeServer = async () => {
     console.error('Failed to start server : ', error);
   }
 };
-
+app.use('/auth', authRoutes);
 app.use('/comments', commentRoutes);
 app.use('/boards/:boardId/posts', postRoute);
 app.use('/api/users', userRoutes);

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,0 +1,84 @@
+import { Request, Response } from 'express';
+import axios from 'axios';
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+import { BadRequestError } from '../errors/httpError';
+
+dotenv.config();
+
+const {
+  GITHUB_CLIENT_ID,
+  GITHUB_CLIENT_SECRET_KEY,
+  GITHUB_CALLBACK_URL,
+  JWT_SECRET_KEY,
+} = process.env;
+
+export const redirectToGitHub = (req: Request, res: Response): void => {
+  const redirectURI = `https://github.com/login/oauth/authorize?client_id=${GITHUB_CLIENT_ID}&redirect_uri=${GITHUB_CALLBACK_URL}&scope=user:email`;
+  res.redirect(redirectURI);
+};
+
+export const handleGitHubCallback = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const code = req.query.code as string;
+
+  if (!code) {
+    throw new BadRequestError();
+  }
+
+  try {
+    const tokenResponse = await axios.post(
+      'https://github.com/login/oauth/access_token',
+      {
+        client_id: GITHUB_CLIENT_ID,
+        client_secret: GITHUB_CLIENT_SECRET_KEY,
+        code,
+      },
+      { headers: { Accept: 'application/json' } }
+    );
+
+    const accessToken = tokenResponse.data.access_token;
+
+    if (!accessToken) {
+      throw new Error('액세스 토큰을 얻지 못했습니다');
+    }
+
+    const userResponse = await axios.get('https://api.github.com/user', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    const userEmailResponse = await axios.get(
+      'https://api.github.com/user/emails',
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }
+    );
+
+    const userInfo = {
+      id: userResponse.data.id,
+      username: userResponse.data.login,
+      email: userEmailResponse.data.find((email: any) => email.primary)?.email,
+    };
+
+    if (!userInfo.email) {
+      throw new Error('이메일을 찾을 수 없습니다');
+    }
+
+    const token = jwt.sign(userInfo, JWT_SECRET_KEY!, { expiresIn: '1h' });
+
+    res.status(200).json({
+      message: 'GitHub 로그인 성공',
+      token,
+      user: userInfo,
+    });
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error occurred';
+    res.status(500).json({
+      error: 'GitHub OAuth Failed',
+      details: errorMessage,
+    });
+  }
+};

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -54,3 +54,22 @@ export const generateRefreshToken = (userId: string): string => {
     expiresIn: process.env.REFRESH_TOKEN_EXPIRY,
   });
 };
+
+/**
+ * 에러 핸들링 미들웨어
+ */
+export const errorHandler = (
+  error: Error & { statusCode?: number },
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const statusCode = error.statusCode || 500;
+  const message = error.message || 'Internal Server Error';
+
+  res.status(statusCode).json({
+    error: true,
+    message,
+    statusCode,
+  });
+};

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import {
+  redirectToGitHub,
+  handleGitHubCallback,
+} from '../controllers/authController';
+
+const router = express.Router();
+
+router.get('/github', redirectToGitHub);
+router.get('/github/callback', handleGitHubCallback);
+
+export default router;


### PR DESCRIPTION
### PR 종류
- [ ] Bugfix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other

### 핵심 내용
- OAuth 프로세스 개요

  - 사용자 리다이렉트: 사용자가 GitHub 로그인 페이지로 이동하도록 리다이렉트.
  - Authorization Code 획득: 사용자가 GitHub 로그인 후 제공한 Authorization Code를 백엔드로 전달.
  - Access Token 요청: Authorization Code를 사용하여 GitHub API로부터 Access Token을 받아옴.
  - 사용자 정보 요청: Access Token으로 GitHub API에 요청하여 사용자 정보를 받아옴.
  - JWT 생성 및 응답: 받은 사용자 정보를 기반으로 JWT를 생성하고 클라이언트에 전달.

### 부가 설명
- client_secret_key와 같은 데이터는 절대 클라이언트에 노출되지 않음
- 로컬 테스트 시 주의사항
  - redirect_uri와 GitHub OAuth 설정의 Authorization callback URL이 정확히 일치해야 함.