### PR TITLE
feat/login - add image information-github login

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -61,6 +61,7 @@ export const handleGitHubCallback = async (
       id: userResponse.data.id,
       username: userResponse.data.login,
       email: userEmailResponse.data.find((email: any) => email.primary)?.email,
+      avatar_url: userResponse.data.avatar_url,
     };
 
     if (!userInfo.email) {
@@ -75,6 +76,6 @@ export const handleGitHubCallback = async (
       user: userInfo,
     });
   } catch (error) {
-    next(error); // 에러를 에러 핸들링 미들웨어로 전달
+    next(error);
   }
 };

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import { BadRequestError } from '../errors/httpError';
+import { createUser, findUserByEmail } from '../repositories/userRepository';
 
 dotenv.config();
 
@@ -66,6 +67,20 @@ export const handleGitHubCallback = async (
 
     if (!userInfo.email) {
       throw new Error('Primary email not found');
+    }
+
+    const userInDatabase = await findUserByEmail(userInfo.email);
+    if (!userInDatabase) {
+      const currentTime = new Date();
+      await createUser({
+        username: userInfo.username,
+        email: userInfo.email,
+        password: null,
+        avatar_url: userInfo.avatar_url,
+        githubId: userInfo.id,
+        createdAt: currentTime,
+        lastLoginAt: currentTime,
+      });
     }
 
     const token = jwt.sign(userInfo, JWT_SECRET_KEY!, { expiresIn: '1h' });

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -3,14 +3,21 @@ import mongoose, { Schema, Document } from 'mongoose';
 export interface IUser extends Document {
   username: string;
   email: string;
-  password: string;
+  password: string | null;
+  avatar_url?: string;
+  githubId?: number;
+  createdAt: Date;
+  lastLoginAt: Date;
 }
 
-const UserSchema: Schema = new Schema<IUser>(
+const UserSchema: Schema = new Schema(
   {
     username: { type: String, required: true },
     email: { type: String, required: true, unique: true },
-    password: { type: String, required: true },
+    password: { type: String, default: null },
+    avatar_url: { type: String },
+    githubId: { type: Number, unique: true },
+    lastLoginAt: { type: Date },
   },
   { timestamps: true }
 );

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -18,7 +18,7 @@ export const registerUser = async (
 
 export const authenticateUser = async (email: string, password: string) => {
   const user = await findUserByEmail(email);
-  if (!user) {
+  if (!user || !user.password) {
     throw new BadRequestError('이메일 또는 비밀번호가 잘못되었습니다.');
   }
 


### PR DESCRIPTION
### PR 종류
- [ ] Bugfix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other

### 핵심 내용
- 깃허브 로그인 시 응답하는 user정보에 이미지 항목 추가
- GitHub 로그인 시 사용자 정보를 데이터베이스에 저장하는 로직 추가
- 사용자의 첫 로그인 시 createdAt(생성시간)과 lastLoginAt(마지막 로그인 시간) 필드 저장

### 부가 설명
- avatar_url 이라는 키로 응답
- GitHub 로그인 응답 처리
  - GitHub 로그인 시 사용자 정보를 받아와 데이터베이스에 저장.